### PR TITLE
Adding setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+exclude = .ipynb*, __init__.py, *.git


### PR DESCRIPTION
- Increased flake8 character count to 100
- ignore non .py files
